### PR TITLE
Custom WakaTime API Endpoint feature

### DIFF
--- a/src/storageHandler.luau
+++ b/src/storageHandler.luau
@@ -36,6 +36,15 @@ function module.setWakaTimeKey(plugin: Plugin, value: string)
 	plugin:SetSetting("WakaTimeKey", value)
 end
 
+function module.getWakaTimeUrl(plugin: Plugin)
+	local value = plugin:GetSetting("WakaTimeUrl") :: string?
+	return if value == nil or value == "" then "https://api.wakatime.com/api/v1" else value
+end
+
+function module.setWakaTimeUrl(plugin: Plugin, value: string)
+	plugin:SetSetting("WakaTimeUrl", value)
+end
+
 function module.getShouldLogPlayTime(plugin: Plugin)
 	local value = plugin:GetSetting("WakaTimeShouldLogPlayTime")
 	return if value == nil then true else value

--- a/src/uiHandler.luau
+++ b/src/uiHandler.luau
@@ -125,7 +125,9 @@ local function MainUI(props: {
 		-- VerticalSpace({ Height = 10 }),
 
 		e(StudioComponents.Label, {
-			Text = "WakaTime API Key",
+			Text = `WakaTime API key{if #keyText > 0
+				then ""
+				else " <b>(Please paste your API key here)</b>"}`,
 			TextXAlignment = Enum.TextXAlignment.Left,
 			Size = UDim2.new(1, 0, 0, 30),
 			RichText = true,

--- a/src/uiHandler.luau
+++ b/src/uiHandler.luau
@@ -58,6 +58,9 @@ local function MainUI(props: {
 	initialApiKey: string,
 	setApiKey: (value: string) -> (),
 
+	initialApiUrl: string,
+	setApiUrl: (value: string) -> (),
+
 	initialShouldLogPlayTime: boolean,
 	setShouldLogPlayTime: (value: boolean) -> (),
 
@@ -69,6 +72,7 @@ local function MainUI(props: {
 })
 	local projectText, setProjectText = React.useState(props.initialProject)
 	local keyText, setKeyText = React.useState(props.initialApiKey)
+	local urlText, setUrlText = React.useState(props.initialApiUrl)
 
 	return e(StudioComponents.ScrollFrame, {
 		PaddingLeft = UDim.new(0, 10),
@@ -103,9 +107,25 @@ local function MainUI(props: {
 		}),
 
 		e(StudioComponents.Label, {
-			Text = `WakaTime API key{if util.isValidWakaTimeApiKey(keyText)
-				then ""
-				else " <b>(Please paste your API key that starts with waka_)</b>"}`,
+			Text = "WakaTime API URL",
+			TextXAlignment = Enum.TextXAlignment.Left,
+			Size = UDim2.new(1, 0, 0, 30),
+			RichText = true,
+		}),
+		e(StudioComponents.TextInput, {
+			Text = urlText,
+			OnChanged = function(newText)
+				setUrlText(newText)
+				props.setApiUrl(newText)
+			end,
+			ClearTextOnFocus = false,
+			PlaceholderText = "https://api.wakatime.com/api/v1"
+		}),
+
+		-- VerticalSpace({ Height = 10 }),
+
+		e(StudioComponents.Label, {
+			Text = "WakaTime API Key",
 			TextXAlignment = Enum.TextXAlignment.Left,
 			Size = UDim2.new(1, 0, 0, 30),
 			RichText = true,
@@ -117,7 +137,7 @@ local function MainUI(props: {
 				props.setApiKey(newText)
 			end,
 			ClearTextOnFocus = false,
-			PlaceholderText = "Get it at wakatime.com/api-key",
+			PlaceholderText = "Get it from wakatime.com or use your key from alternative source",
 		}),
 
 		VerticalSpace({ Height = 10 }),
@@ -173,6 +193,11 @@ function module.init(plugin: Plugin)
 		initialApiKey = storageHandler.getWakaTimeKey(plugin) or "",
 		setApiKey = function(value)
 			storageHandler.setWakaTimeKey(plugin, value)
+		end,
+
+		initialApiUrl = storageHandler.getWakaTimeUrl(plugin) or "https://api.wakatime.com/api/v1",
+		setApiUrl = function(value)
+			storageHandler.setWakaTimeUrl(plugin, value)
 		end,
 
 		initialShouldLogPlayTime = storageHandler.getShouldLogPlayTime(plugin),

--- a/src/util.luau
+++ b/src/util.luau
@@ -17,8 +17,19 @@ function module.trimString(s: string)
 	return s:match("^%s*(.-)%s*$")
 end
 
-function module.isValidWakaTimeApiKey(key: string)
-	return key:match("^waka_") ~= nil
+-- Thanks for amazing work of xDeltaXen (https://devforum.roblox.com/t/base64-encoding-and-decoding-in-lua/1719860)
+function module.encode(data: string): string
+    local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+    return ((data:gsub('.', function(x) 
+        local r,b='',x:byte()
+        for i=8,1,-1 do r=r..(b%2^i-b%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end)..'0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+        if (#x < 6) then return '' end
+        local c=0
+        for i=1,6 do c=c+(x:sub(i,i)=='1' and 2^(6-i) or 0) end
+        return b:sub(c+1,c+1)
+    end)..({ '', '==', '=' })[#data%3+1])
 end
 
 return module

--- a/src/wakatime.luau
+++ b/src/wakatime.luau
@@ -40,15 +40,17 @@ end
 
 local function sendHeartbeat(plugin: Plugin, activity: StudioActivity)
 	local apiKey = storageHandler.getWakaTimeKey(plugin)
-	if not apiKey or not util.isValidWakaTimeApiKey(apiKey) then
+	local apiUrl = storageHandler.getWakaTimeUrl(plugin)
+	if not apiKey or not apiUrl then
 		return
 	end
+	apiKey = util.encode(apiKey)
 
 	local now = DateTime.now().UnixTimestamp
 	local bodyToSend = {
 		time = now,
 		branch = `{game.PlaceId}`,
-		plugin = `Roblox Studio/{settings().Diagnostics.RobloxVersion} roblox-studio-wakatime/0.1.0`,
+		plugin = `Roblox Studio/{settings().Diagnostics.RobloxVersion} roblox-studio-wakatime/1.0.0`,
 	}
 	local projectName = storageHandler.getProjectName(plugin)
 	if projectName and #projectName > 0 then
@@ -88,7 +90,7 @@ local function sendHeartbeat(plugin: Plugin, activity: StudioActivity)
 	lastSentActivity = activity
 
 	local ok, response = pcall(HttpService.RequestAsync, HttpService, {
-		Url = "https://api.wakatime.com/api/v1/users/current/heartbeats",
+		Url = apiUrl .. "/users/current/heartbeats",
 		Method = "POST",
 		Body = HttpService:JSONEncode(bodyToSend),
 		Headers = {
@@ -97,7 +99,7 @@ local function sendHeartbeat(plugin: Plugin, activity: StudioActivity)
 		},
 	})
 	if ok then
-		-- print("Sent WakaTime heartbeat", bodyToSend)
+		-- print("Sent WakaTime heartbeat", bodyToSend, response.Body)
 	else
 		warn("Failed to call WakaTime API.", response.Body)
 	end

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tacheometry/roblox-studio-wakatime"
-version = "0.1.0"
+version = "1.0.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
Hello,

This is a very nice plugin and it works really well, but I have one issue with it. I don't use WakaTime, but a self-hosted alternative called Wakapi, so I added a new setting that allows users to specify any URL they want.

**Changes I made:**
- Added a new field "WakaTime URL" to the UI
- Completely removed the `isValidWakaTimeKey` function (because API keys don't always start with `waka_` in WakaTime alternatives)
- Added base64 encoding for `apiKey` in `wakatime.luau`
- Bumped the version to 1.0

I hope you don't mind, but I think it would be nice to release this version as 1.0 instead of 0.2.0, since I think that this plugin is finished.

Thanks. 🙂
